### PR TITLE
finalmodel: remove spurious add_plot(WAXSiS) from convergence-changed…

### DIFF
--- a/bin/finalmodel.php
+++ b/bin/finalmodel.php
@@ -432,13 +432,17 @@ if ( $load_convergence !== $input->waxsis_convergence_mode ) {
 
     ## reload model 0 WAXSiS data into the sas object, interpolated and scaled onto Exp. I(q) grid
     ## (mirrors the per-model loop: load -> interpolate -> scale_nchi2 -> remove intermediates)
+    ## NOTE: do NOT add_plot here — model 0 belongs in the plot only if NNLS gives it non-zero
+    ## weight, which is handled by the NNLS results loop below (same as every other frame).
+    ## Adding it here with the pre-rename name "WAXSiS" and then calling rename_data() would
+    ## leave a stale "WAXSiS" trace in the plot because rename_data() only renames the data
+    ## store key, not the name field of any already-added plot trace.
     $sas->remove_data( "WAXSiS" );
     $sas->load_file( SAS::PLOT_IQ, "WAXSiS org", $waxsis_model0_cached_file );
     $sas->interpolate( "WAXSiS org", "Exp. I(q)", "WAXSiS interp" );
     $sas->scale_nchi2( "Exp. I(q)", "WAXSiS interp", "WAXSiS", $chi2, $scale );
     $sas->remove_data( "WAXSiS org" );
     $sas->remove_data( "WAXSiS interp" );
-    $sas->add_plot( $plotname, "WAXSiS" );
 } else {
     if ( !file_exists( $waxsis_model0_cached_file ) ) {
         ## first run after this feature was added: cache the existing result


### PR DESCRIPTION
… block

When WAXSiS convergence mode changed between Load Structure and Final Model, model 0 data was reloaded and immediately added to the plot via add_plot(plotname, WAXSiS). The subsequent rename_data(WAXSiS, I(q) WAXSiS mod. 0) only renames the data store key - it does not update the name field of a plot trace already added. This left a stale WAXSiS trace in the plot.

When NNLS gave model 0 zero weight the stale trace was the only model-0 curve visible, producing a spurious WAXSiS line in the iqplotwaxsis plot. When model 0 had non-zero NNLS weight the data appeared twice in the plot.

Fix: remove the add_plot call from the convergence block entirely. Model 0 data is in the SAS store (renamed to I(q) WAXSiS mod. 0) and is included in NNLS via alliqframes. If NNLS selects it, the results loop adds it to the plot with the correct name - same path used for every other frame.