### PR TITLE
feat: add Rg column to NNLS summary table and fix stale WAXSiS trace

### DIFF
--- a/bin/common.php
+++ b/bin/common.php
@@ -185,17 +185,28 @@ function progress_text( $msg, $decor = '&diams;&diams;&diams;', $just_return_str
     $ga->tcpmessage( [ 'progress_text' => $str ] );
 }
 
-function nnls_results_to_html( $obj ) {
+function nnls_results_to_html( $obj, $rg_map = null ) {
+    $show_rg = !empty( $rg_map );
+    $rg_th   = $show_rg ? "<th style='padding:0 15px 0 15px'>Rg [&#8491;]</th>" : "";
     $res =
         "<div style='font-family:monospace;width=100%'><small>"
         . "<table>"
-        . "<tr><th style='padding:0 15px 0 15px;text-align:center'>&nbsp;Model&nbsp;</th><th style='padding:0 15px 0 15px'>&nbsp;Fit contrib. %&nbsp;</th></tr>"
+        . "<tr><th style='padding:0 15px 0 15px;text-align:center'>&nbsp;Model&nbsp;</th>"
+        . $rg_th
+        . "<th style='padding:0 15px 0 15px'>&nbsp;Fit contrib. %&nbsp;</th></tr>"
         ;
 
     foreach ( $obj as $k => $v ) {
-
+        $rg_td = "";
+        if ( $show_rg ) {
+            $rg_td = isset( $rg_map[ $k ] )
+                ? "<td style='padding:0 15px 0 15px;text-align:center'>" . sprintf( "%.1f", $rg_map[ $k ] ) . "</td>"
+                : "<td style='padding:0 15px 0 15px;text-align:center'>&#8212;</td>";
+        }
         $res .=
-            "<tr><td style='padding:0 15px 0 15px'>&nbsp;$k&nbsp;</td><td style='padding:0 15px 0 15px;text-align:center'>"
+            "<tr><td style='padding:0 15px 0 15px'>&nbsp;$k&nbsp;</td>"
+            . $rg_td
+            . "<td style='padding:0 15px 0 15px;text-align:center'>"
             . sprintf( "%.1f", 100 * $v )
             . "</td></tr>"
             ;

--- a/bin/finalmodel.php
+++ b/bin/finalmodel.php
@@ -432,13 +432,17 @@ if ( $load_convergence !== $input->waxsis_convergence_mode ) {
 
     ## reload model 0 WAXSiS data into the sas object, interpolated and scaled onto Exp. I(q) grid
     ## (mirrors the per-model loop: load -> interpolate -> scale_nchi2 -> remove intermediates)
+    ## NOTE: do NOT add_plot here — model 0 belongs in the plot only if NNLS gives it non-zero
+    ## weight, which is handled by the NNLS results loop below (same as every other frame).
+    ## Adding it here with the pre-rename name "WAXSiS" and then calling rename_data() would
+    ## leave a stale "WAXSiS" trace in the plot because rename_data() only renames the data
+    ## store key, not the name field of any already-added plot trace.
     $sas->remove_data( "WAXSiS" );
     $sas->load_file( SAS::PLOT_IQ, "WAXSiS org", $waxsis_model0_cached_file );
     $sas->interpolate( "WAXSiS org", "Exp. I(q)", "WAXSiS interp" );
     $sas->scale_nchi2( "Exp. I(q)", "WAXSiS interp", "WAXSiS", $chi2, $scale );
     $sas->remove_data( "WAXSiS org" );
     $sas->remove_data( "WAXSiS interp" );
-    $sas->add_plot( $plotname, "WAXSiS" );
 } else {
     if ( !file_exists( $waxsis_model0_cached_file ) ) {
         ## first run after this feature was added: cache the existing result
@@ -709,7 +713,26 @@ $output->iqplotwaxsis = $sas->plot( $plotname );
 $fitname = $input->_project . ".fit";
 $sas->save_fit( "Exp. I(q)", "I(q)<sub>W</sub> NNLS fit", $fitname );
 
-$output->iqresultswaxsis = nnls_results_to_html( $iqresults );
+require_once "plotlyhist.php";
+
+$rg_map = [];
+
+if ( isset( $cgstate->state->output_load->Rg ) && isset( $iqresults[ $waxsis_data_name ] ) ) {
+    $rg_map[ $waxsis_data_name ] = $cgstate->state->output_load->Rg;
+}
+
+if ( isset( $cgstate->state->mmcdownloaded ) ) {
+    $histname  = "monomer_monte_carlo/" . $cgstate->state->mmcrunname . ".dcd.accepted_rg_results_data.txt";
+    $frame_rgs = frame_rgs_from_hist( $histname );
+    foreach ( $iqresults as $name => $v ) {
+        $frame = intval( end( explode( ' ', $name ) ) );
+        if ( $frame > 0 && isset( $frame_rgs[ $frame - 1 ] ) ) {
+            $rg_map[ $name ] = $frame_rgs[ $frame - 1 ];
+        }
+    }
+}
+
+$output->iqresultswaxsis = nnls_results_to_html( $iqresults, $rg_map ?: null );
 
 ### save results to state
 
@@ -854,8 +877,6 @@ $ga->tcpmessage(
 $output->iqplotwaxsis = $sas->plot( $plotname );
 
 ## final rg plot
-
-require_once "plotlyhist.php";
 
 $rgdata = (object) [];
 

--- a/bin/joinresults.php
+++ b/bin/joinresults.php
@@ -336,7 +336,33 @@ if ( strlen( $annotate_msg ) ) {
 
 ### summary results
 
-$output->iqresultswaxsis = nnls_results_to_html( $iqresults );
+require_once "plotlyhist.php";
+
+$proj_frame_rgs = [];
+foreach ( $input->projects as $project ) {
+    $cgs = $cgstates->$project;
+    if ( isset( $cgs->state->mmcdownloaded ) ) {
+        $histname = "../$project/monomer_monte_carlo/" . $cgs->state->mmcrunname . ".dcd.accepted_rg_results_data.txt";
+        $proj_frame_rgs[ $project ] = frame_rgs_from_hist( $histname );
+    }
+}
+
+$rg_map    = [];
+$model0_rg = $cgstates->{$best->iq->project}->state->output_load->Rg ?? null;
+
+foreach ( $iqresults as $name => $v ) {
+    $frame = intval( end( explode( ' ', $name ) ) );
+    if ( $frame === 0 && $model0_rg !== null ) {
+        $rg_map[ $name ] = $model0_rg;
+    } elseif ( $frame > 0 && preg_match( '/^([^:]+):/', $name, $m ) ) {
+        $project = $m[1];
+        if ( isset( $proj_frame_rgs[ $project ][ $frame - 1 ] ) ) {
+            $rg_map[ $name ] = $proj_frame_rgs[ $project ][ $frame - 1 ];
+        }
+    }
+}
+
+$output->iqresultswaxsis = nnls_results_to_html( $iqresults, $rg_map ?: null );
 
 $output->iqplotwaxsis = $sas->plot( $plotname );
 
@@ -595,8 +621,6 @@ $output->$pr_recon_id->layout->title->text =
     str_replace( "vs starting", "vs starting struct. for project " . $best->pr->project, $output->$pr_recon_id->layout->title->text );
 
 ## final rg plot
-
-require_once "plotlyhist.php";
 
 $rgdata = (object) [];
 

--- a/bin/plotlyhist.php
+++ b/bin/plotlyhist.php
@@ -378,7 +378,6 @@ function final_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata, $adjac
             $pos    = 0;
             $avgrg2 = 0;
 
-            file_put_contents( "/tmp/checkrg", "plotlyhist final func() running\n",  FILE_APPEND );
             foreach ( $nnlsresults as $k => $v ) {
                 $namev = explode( ' ', $k );
                 $model = end( $namev );
@@ -444,6 +443,23 @@ function final_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata, $adjac
 
         }
     }
+}
+
+function frame_rgs_from_hist( $histname ) {
+    // Returns float[] indexed 0-based (frame 1 at index 0), or [] if file missing.
+    if ( !file_exists( $histname ) ) {
+        return [];
+    }
+    $rgs   = [];
+    $lines = explode( "\n", file_get_contents( $histname ) );
+    array_shift( $lines ); // skip header
+    foreach ( $lines as $line ) {
+        $vals = preg_split( '/\s+/', trim( $line ) );
+        if ( count( $vals ) >= 2 ) {
+            $rgs[] = floatval( $vals[1] );
+        }
+    }
+    return $rgs;
 }
 
 function merge_histograms( $x1, $y1, $x2, $y2, $n_bins ) {


### PR DESCRIPTION
Each NNLS model Rg shown alongside fit contrib % in iqresultswaxsis table.

- plotlyhist.php: add frame_rgs_from_hist() helper; remove debug file_put_contents
- common.php: nnls_results_to_html() accepts optional rg_map for Rg column
- finalmodel.php: build rg_map before summary; fix stale add_plot in convergence block
- joinresults.php: same pattern with per-project histogram lookups