### PR TITLE
feat: display WAXSiS solvated Rg in Load Structure

### DIFF
--- a/bin/loadstructure.php
+++ b/bin/loadstructure.php
@@ -98,6 +98,7 @@ $ga->tcpmessage( [
                      ,"psv"                => ''
                      ,"hyd"                => ''
                      ,"Rg"                 => ''
+                     ,"Rg_ws"              => ''
 #                     ,"ExtX"               => ''
 #                     ,"ExtY"               => ''
 #                     ,"ExtZ"               => ''
@@ -707,6 +708,12 @@ if ( 1 ) {
     $time_end   = dt_now();
     $cgstate->state->waxsis_last_run_time_minutes = dt_duration_minutes( $time_start, $time_end );
     run_cmd( "cp waxsis/intensity_waxsis.calc $waxsis_cached_file" );
+    $waxsis_notes_cached = "waxsis/notes${waxsis_suffix}.log";
+    if ( file_exists( "waxsis/notes.log" ) ) {
+        run_cmd( "cp waxsis/notes.log $waxsis_notes_cached", false );
+    }
+    $notes_rg = waxsis_rg_from_notes( $waxsis_notes_cached );
+    $output->Rg_ws = digitfix( sprintf( "%.3g", $notes_rg->rg ), 3 );
 }
 
 ## waxsis done, release elastic resources

--- a/bin/waxsis.php
+++ b/bin/waxsis.php
@@ -148,6 +148,21 @@ function run_waxsis( $pdb, $config, $cb_on_write, $exit_waxsis_error = true ) {
     return true;
 }
 
+function waxsis_rg_from_notes( $notes_file ) {
+    if ( !file_exists( $notes_file ) ) {
+        error_exit( "WAXSiS notes file '$notes_file' does not exist" );
+    }
+    $content = file_get_contents( $notes_file );
+    if ( !preg_match( '/Rg \[A\]\s*=\s*([\d.]+)/', $content, $m ) ) {
+        error_exit( "Could not parse Rg from WAXSiS notes file '$notes_file'" );
+    }
+    $rg = floatval( $m[1] );
+    if ( !preg_match( '/Rg\(solute\) \[A\]\s*=\s*([\d.]+)/', $content, $m ) ) {
+        error_exit( "Could not parse Rg(solute) from WAXSiS notes file '$notes_file'" );
+    }
+    return (object)[ 'rg' => $rg, 'rg_solute' => floatval( $m[1] ) ];
+}
+
 ## testing
 
 # waxis_load_data( "waxsis/fittedCalcInterpolated_waxsis.fit", $waxsis_fitted_data );

--- a/modules/loadstructure.json
+++ b/modules/loadstructure.json
@@ -472,7 +472,18 @@
                 "parent" : "resultpanel"
             }
         },
-        {
+        ,{
+            "type"           : "text"
+            ,"help"          : "WAXSiS Guinier R<sub>g</sub> computed on the fully solvated structure (hydration shell modeled explicitly by WAXSiS). Compare with the dry R<sub>g</sub> above &mdash; the difference reflects the contribution of the bound solvent layer."
+            ,"id"            : "Rg_ws"
+            ,"role"          : "output"
+            ,"label"         : "WAXSiS R<sub>g</sub> (solvated) [&#8491;]"
+            ,"labelmargintop": "0.5rem"
+            ,"layout"        : {
+                "parent" : "resultpanel"
+            }
+        }
+        ,{
             "type" : "text",
             "help" : "The percent of peptide bonds identified by DSSP, implemented in UCSF Chimera, as &alpha;-Helix",
             "id" : "helix",


### PR DESCRIPTION
Adds waxsis_rg_from_notes() to parse Rg and Rg(solute) from the WAXSiS notes.log after each run, caches it as notes${suffix}.log, and exposes the hydrated Rg as Rg_ws in the UI and state.json (output_load->Rg_ws).