### PR TITLE
feat: use WAXSiS Guinier Rg in NNLS summary for finalmodel and joinre…

### DIFF
--- a/bin/common.php
+++ b/bin/common.php
@@ -185,9 +185,9 @@ function progress_text( $msg, $decor = '&diams;&diams;&diams;', $just_return_str
     $ga->tcpmessage( [ 'progress_text' => $str ] );
 }
 
-function nnls_results_to_html( $obj, $rg_map = null ) {
+function nnls_results_to_html( $obj, $rg_map = null, $rg_header = 'Rg [&#8491;]' ) {
     $show_rg = !empty( $rg_map );
-    $rg_th   = $show_rg ? "<th style='padding:0 15px 0 15px'>Rg [&#8491;]</th>" : "";
+    $rg_th   = $show_rg ? "<th style='padding:0 15px 0 15px'>$rg_header</th>" : "";
     $res =
         "<div style='font-family:monospace;width=100%'><small>"
         . "<table>"

--- a/bin/finalmodel.php
+++ b/bin/finalmodel.php
@@ -428,6 +428,9 @@ if ( $load_convergence !== $input->waxsis_convergence_mode ) {
             error_exit( "WAXSiS did not produce the expected I(q) file for model 0" );
         }
         run_cmd( "cp waxsis/intensity_waxsis.calc $waxsis_model0_cached_file" );
+        if ( file_exists( "waxsis/waxsisrun/notes.log" ) ) {
+            run_cmd( "cp waxsis/waxsisrun/notes.log waxsis/notes${waxsis_suffix}.log", false );
+        }
     }
 
     ## reload model 0 WAXSiS data into the sas object, interpolated and scaled onto Exp. I(q) grid
@@ -583,6 +586,11 @@ foreach ( $names as $name ) {
                 }
 
                 run_cmd( "mv $waxsisiqfile $iqfile" );
+                $notes_src  = $waxsis_params->subdir . "/waxsisrun/notes.log";
+                $notes_dest = "$procdir/$pdbnoext-waxsis${waxsis_suffix}-notes.log";
+                if ( file_exists( $notes_src ) ) {
+                    run_cmd( "cp $notes_src $notes_dest", false );
+                }
                 $iqfiles[] = $iqfile;
             } else {
                 $waxsis_failures[] = $frame;
@@ -715,19 +723,38 @@ $sas->save_fit( "Exp. I(q)", "I(q)<sub>W</sub> NNLS fit", $fitname );
 
 require_once "plotlyhist.php";
 
-$rg_map = [];
-
-if ( isset( $cgstate->state->output_load->Rg ) && isset( $iqresults[ $waxsis_data_name ] ) ) {
-    $rg_map[ $waxsis_data_name ] = $cgstate->state->output_load->Rg;
+$notes_rgs     = [];
+$m0_notes_file = "waxsis/notes${waxsis_suffix}.log";
+if ( file_exists( $m0_notes_file ) ) {
+    $notes_rgs[ $waxsis_data_name ] = waxsis_rg_from_notes( $m0_notes_file );
+}
+foreach ( $iqresults as $name => $v ) {
+    $frame = intval( end( explode( ' ', $name ) ) );
+    if ( $frame > 0 ) {
+        $frame_padded = str_repeat( '0', $max_frame_digits - strlen( $frame ) ) . $frame;
+        $notes_file   = "$procdir/${bname}-somo-m${frame_padded}-waxsis${waxsis_suffix}-notes.log";
+        if ( file_exists( $notes_file ) ) {
+            $notes_rgs[ $name ] = waxsis_rg_from_notes( $notes_file );
+        }
+    }
 }
 
+$rg_map = [];
+foreach ( $notes_rgs as $name => $rg_obj ) {
+    $rg_map[ $name ] = $rg_obj->rg;
+}
+if ( !isset( $rg_map[ $waxsis_data_name ] ) && isset( $cgstate->state->output_load->Rg ) && isset( $iqresults[ $waxsis_data_name ] ) ) {
+    $rg_map[ $waxsis_data_name ] = $cgstate->state->output_load->Rg;
+}
 if ( isset( $cgstate->state->mmcdownloaded ) ) {
     $histname  = "monomer_monte_carlo/" . $cgstate->state->mmcrunname . ".dcd.accepted_rg_results_data.txt";
     $frame_rgs = frame_rgs_from_hist( $histname );
     foreach ( $iqresults as $name => $v ) {
-        $frame = intval( end( explode( ' ', $name ) ) );
-        if ( $frame > 0 && isset( $frame_rgs[ $frame - 1 ] ) ) {
-            $rg_map[ $name ] = $frame_rgs[ $frame - 1 ];
+        if ( !isset( $rg_map[ $name ] ) ) {
+            $frame = intval( end( explode( ' ', $name ) ) );
+            if ( $frame > 0 && isset( $frame_rgs[ $frame - 1 ] ) ) {
+                $rg_map[ $name ] = $frame_rgs[ $frame - 1 ];
+            }
         }
     }
 }
@@ -736,7 +763,8 @@ $output->iqresultswaxsis = nnls_results_to_html( $iqresults, $rg_map ?: null );
 
 ### save results to state
 
-$cgstate->state->iq_waxsis_nnlsresults = json_decode( json_encode( $iqresults ) );
+$cgstate->state->iq_waxsis_nnlsresults    = json_decode( json_encode( $iqresults ) );
+$cgstate->state->waxsis_final_convergence = $input->waxsis_convergence_mode;
 
 ## setup csvdownloads
 

--- a/bin/finalmodel.php
+++ b/bin/finalmodel.php
@@ -739,18 +739,22 @@ foreach ( $iqresults as $name => $v ) {
     }
 }
 
-$rg_map = [];
-foreach ( $notes_rgs as $name => $rg_obj ) {
-    $rg_map[ $name ] = $rg_obj->rg;
-}
-if ( !isset( $rg_map[ $waxsis_data_name ] ) && isset( $cgstate->state->output_load->Rg ) && isset( $iqresults[ $waxsis_data_name ] ) ) {
-    $rg_map[ $waxsis_data_name ] = $cgstate->state->output_load->Rg;
-}
-if ( isset( $cgstate->state->mmcdownloaded ) ) {
-    $histname  = "monomer_monte_carlo/" . $cgstate->state->mmcrunname . ".dcd.accepted_rg_results_data.txt";
-    $frame_rgs = frame_rgs_from_hist( $histname );
-    foreach ( $iqresults as $name => $v ) {
-        if ( !isset( $rg_map[ $name ] ) ) {
+$rg_map    = [];
+$rg_header = 'Rg [&#8491;]';
+
+if ( count( $notes_rgs ) === count( $iqresults ) ) {
+    foreach ( $notes_rgs as $name => $rg_obj ) {
+        $rg_map[ $name ] = $rg_obj->rg;
+    }
+    $rg_header = 'Rg solv. [&#8491;]';
+} else {
+    if ( isset( $cgstate->state->output_load->Rg ) && isset( $iqresults[ $waxsis_data_name ] ) ) {
+        $rg_map[ $waxsis_data_name ] = $cgstate->state->output_load->Rg;
+    }
+    if ( isset( $cgstate->state->mmcdownloaded ) ) {
+        $histname  = "monomer_monte_carlo/" . $cgstate->state->mmcrunname . ".dcd.accepted_rg_results_data.txt";
+        $frame_rgs = frame_rgs_from_hist( $histname );
+        foreach ( $iqresults as $name => $v ) {
             $frame = intval( end( explode( ' ', $name ) ) );
             if ( $frame > 0 && isset( $frame_rgs[ $frame - 1 ] ) ) {
                 $rg_map[ $name ] = $frame_rgs[ $frame - 1 ];
@@ -759,7 +763,7 @@ if ( isset( $cgstate->state->mmcdownloaded ) ) {
     }
 }
 
-$output->iqresultswaxsis = nnls_results_to_html( $iqresults, $rg_map ?: null );
+$output->iqresultswaxsis = nnls_results_to_html( $iqresults, $rg_map ?: null, $rg_header );
 
 ### save results to state
 

--- a/bin/joinresults.php
+++ b/bin/joinresults.php
@@ -348,7 +348,7 @@ foreach ( $input->projects as $project ) {
     }
 }
 
-$rg_map = [];
+$notes_rgs = [];
 foreach ( $iqresults as $name => $v ) {
     $frame = intval( end( explode( ' ', $name ) ) );
     if ( !preg_match( '/^([^:]+):/', $name, $m ) ) {
@@ -368,15 +368,34 @@ foreach ( $iqresults as $name => $v ) {
         $notes_file   = "../$project/waxsissets/${bname}-somo-m${frame_padded}-waxsis${suffix}-notes.log";
     }
     if ( file_exists( $notes_file ) ) {
-        $rg_map[ $name ] = waxsis_rg_from_notes( $notes_file )->rg;
-    } elseif ( $frame === 0 && isset( $cgstates->$project->state->output_load->Rg ) ) {
-        $rg_map[ $name ] = $cgstates->$project->state->output_load->Rg;
-    } elseif ( $frame > 0 && isset( $proj_frame_rgs[ $project ][ $frame - 1 ] ) ) {
-        $rg_map[ $name ] = $proj_frame_rgs[ $project ][ $frame - 1 ];
+        $notes_rgs[ $name ] = waxsis_rg_from_notes( $notes_file );
     }
 }
 
-$output->iqresultswaxsis = nnls_results_to_html( $iqresults, $rg_map ?: null );
+$rg_map    = [];
+$rg_header = 'Rg [&#8491;]';
+
+if ( count( $notes_rgs ) === count( $iqresults ) ) {
+    foreach ( $notes_rgs as $name => $rg_obj ) {
+        $rg_map[ $name ] = $rg_obj->rg;
+    }
+    $rg_header = 'Rg solv. [&#8491;]';
+} else {
+    foreach ( $iqresults as $name => $v ) {
+        $frame = intval( end( explode( ' ', $name ) ) );
+        if ( !preg_match( '/^([^:]+):/', $name, $m ) ) {
+            continue;
+        }
+        $project = $m[1];
+        if ( $frame === 0 && isset( $cgstates->$project->state->output_load->Rg ) ) {
+            $rg_map[ $name ] = $cgstates->$project->state->output_load->Rg;
+        } elseif ( $frame > 0 && isset( $proj_frame_rgs[ $project ][ $frame - 1 ] ) ) {
+            $rg_map[ $name ] = $proj_frame_rgs[ $project ][ $frame - 1 ];
+        }
+    }
+}
+
+$output->iqresultswaxsis = nnls_results_to_html( $iqresults, $rg_map ?: null, $rg_header );
 
 $output->iqplotwaxsis = $sas->plot( $plotname );
 

--- a/bin/joinresults.php
+++ b/bin/joinresults.php
@@ -25,6 +25,7 @@ include "genapp.php";
 include "datetime.php";
 include_once "common.php";
 include_once "computeiqpr_defines.php";
+require_once "waxsis.php";
 
 
 $ga        = new GenApp( $input, $output );
@@ -347,18 +348,31 @@ foreach ( $input->projects as $project ) {
     }
 }
 
-$rg_map    = [];
-$model0_rg = $cgstates->{$best->iq->project}->state->output_load->Rg ?? null;
-
+$rg_map = [];
 foreach ( $iqresults as $name => $v ) {
     $frame = intval( end( explode( ' ', $name ) ) );
-    if ( $frame === 0 && $model0_rg !== null ) {
-        $rg_map[ $name ] = $model0_rg;
-    } elseif ( $frame > 0 && preg_match( '/^([^:]+):/', $name, $m ) ) {
-        $project = $m[1];
-        if ( isset( $proj_frame_rgs[ $project ][ $frame - 1 ] ) ) {
-            $rg_map[ $name ] = $proj_frame_rgs[ $project ][ $frame - 1 ];
-        }
+    if ( !preg_match( '/^([^:]+):/', $name, $m ) ) {
+        continue;
+    }
+    $project = $m[1];
+    $bname   = preg_replace( '/-somo\.pdb$/', '', $cgstates->$project->state->output_load->name );
+    switch ( $cgstates->$project->state->waxsis_final_convergence ?? 'normal' ) {
+        case 'thorough': $suffix = '_t'; break;
+        case 'quick':    $suffix = '_q'; break;
+        default:         $suffix = '_n'; break;
+    }
+    if ( $frame === 0 ) {
+        $notes_file = "../$project/waxsis/notes${suffix}.log";
+    } else {
+        $frame_padded = str_repeat( '0', $max_frame_digits - strlen( $frame ) ) . $frame;
+        $notes_file   = "../$project/waxsissets/${bname}-somo-m${frame_padded}-waxsis${suffix}-notes.log";
+    }
+    if ( file_exists( $notes_file ) ) {
+        $rg_map[ $name ] = waxsis_rg_from_notes( $notes_file )->rg;
+    } elseif ( $frame === 0 && isset( $cgstates->$project->state->output_load->Rg ) ) {
+        $rg_map[ $name ] = $cgstates->$project->state->output_load->Rg;
+    } elseif ( $frame > 0 && isset( $proj_frame_rgs[ $project ][ $frame - 1 ] ) ) {
+        $rg_map[ $name ] = $proj_frame_rgs[ $project ][ $frame - 1 ];
     }
 }
 


### PR DESCRIPTION
…sults

Copies notes.log after each WAXSiS run (per-frame and model 0 recompute), builds a $notes_rgs map from the cached notes files, and populates $rg_map with the WAXSiS hydrated Rg — falling back to MMC histogram Rg or SOMO dry Rg for older projects without notes files. Saves waxsis_final_convergence to state so joinresults can derive the correct notes filename suffix per project.