### PR TITLE
feat: use solvated Rg in histogram when universally available

### DIFF
--- a/bin/finalmodel.php
+++ b/bin/finalmodel.php
@@ -570,10 +570,6 @@ foreach ( $names as $name ) {
     if ( !$do_testing ) {
         $iqfile     = "$procdir/$pdbnoext-waxsis${waxsis_suffix}.dat";
         $notes_dest = "$procdir/$pdbnoext-waxsis${waxsis_suffix}-notes.log";
-        if ( file_exists( $iqfile ) && !file_exists( $notes_dest ) ) {
-            $ga->tcpmessage( [ '_textarea' => "Frame $frame WAXSiS cache missing notes file, re-running\n" ] );
-            unlink( $iqfile );
-        }
         if ( !file_exists( $iqfile ) ) {
             $time_start = dt_now();
             $ok =

--- a/bin/finalmodel.php
+++ b/bin/finalmodel.php
@@ -926,7 +926,7 @@ $output->iqplotwaxsis = $sas->plot( $plotname );
 $rgdata = (object) [];
 
 if ( isset( $cgstate->state->output_load->Rg ) ) {
-    $rgdata->{ "Original model<br>SOMO computed" } =
+    $rgdata->{ "Original model<br>SOMO (dry)" } =
         (object) [
             "Rg" => $cgstate->state->output_load->Rg
             ,"color" => "blue"

--- a/bin/finalmodel.php
+++ b/bin/finalmodel.php
@@ -744,10 +744,12 @@ foreach ( $iqresults as $name => $v ) {
     }
 }
 
-$rg_map    = [];
-$rg_header = 'Rg [&#8491;]';
+$rg_map       = [];
+$rg_header    = 'Rg [&#8491;]';
+$use_solvated = false;
 
 if ( !empty( $notes_rgs ) && empty( array_diff_key( $iqresults, $notes_rgs ) ) ) {
+    $use_solvated = true;
     foreach ( $notes_rgs as $name => $rg_obj ) {
         $rg_map[ $name ] = $rg_obj->rg;
     }
@@ -923,7 +925,13 @@ $output->iqplotwaxsis = $sas->plot( $plotname );
 
 $rgdata = (object) [];
 
-if ( isset( $cgstate->state->output_load->Rg ) ) {
+if ( $use_solvated && isset( $cgstate->state->output_load->Rg_ws ) ) {
+    $rgdata->{ "Original model<br>WAXSiS (solv.)" } =
+        (object) [
+            "Rg" => floatval( $cgstate->state->output_load->Rg_ws )
+            ,"color" => "blue"
+        ];
+} elseif ( isset( $cgstate->state->output_load->Rg ) ) {
     $rgdata->{ "Original model<br>SOMO computed" } =
         (object) [
             "Rg" => $cgstate->state->output_load->Rg
@@ -944,7 +952,7 @@ if ( isset( $cgstate->state->output_load->prplot ) ) {
         ];
 }
 
-final_hist( $output, $cgstate->state->iq_waxsis_nnlsresults, $cgstate->state->iq_waxsis_nnlsresults_colors, $rgdata, $input->adjacent_frames );
+final_hist( $output, $cgstate->state->iq_waxsis_nnlsresults, $cgstate->state->iq_waxsis_nnlsresults_colors, $rgdata, $input->adjacent_frames, $notes_rgs );
 $cgstate->state->final_adjacent_frames = $input->adjacent_frames;
 
 ## pr reconstruct

--- a/bin/finalmodel.php
+++ b/bin/finalmodel.php
@@ -925,13 +925,7 @@ $output->iqplotwaxsis = $sas->plot( $plotname );
 
 $rgdata = (object) [];
 
-if ( $use_solvated && isset( $cgstate->state->output_load->Rg_ws ) ) {
-    $rgdata->{ "Original model<br>WAXSiS (solv.)" } =
-        (object) [
-            "Rg" => floatval( $cgstate->state->output_load->Rg_ws )
-            ,"color" => "blue"
-        ];
-} elseif ( isset( $cgstate->state->output_load->Rg ) ) {
+if ( isset( $cgstate->state->output_load->Rg ) ) {
     $rgdata->{ "Original model<br>SOMO computed" } =
         (object) [
             "Rg" => $cgstate->state->output_load->Rg

--- a/bin/joinresults.php
+++ b/bin/joinresults.php
@@ -372,10 +372,12 @@ foreach ( $iqresults as $name => $v ) {
     }
 }
 
-$rg_map    = [];
-$rg_header = 'Rg [&#8491;]';
+$rg_map       = [];
+$rg_header    = 'Rg [&#8491;]';
+$use_solvated = false;
 
 if ( !empty( $notes_rgs ) && empty( array_diff_key( $iqresults, $notes_rgs ) ) ) {
+    $use_solvated = true;
     foreach ( $notes_rgs as $name => $rg_obj ) {
         $rg_map[ $name ] = $rg_obj->rg;
     }
@@ -663,7 +665,13 @@ $output->$pr_recon_id->layout->title->text =
 
 $rgdata = (object) [];
 
-if ( isset( $cgstates->{$best->iq->project}->state->output_load->Rg ) ) {
+if ( $use_solvated && isset( $cgstates->{$best->iq->project}->state->output_load->Rg_ws ) ) {
+    $rgdata->{ "Original model<br>Project " . $best->iq->project . "<br>WAXSiS (solv.)" } =
+        (object) [
+            "Rg" => floatval( $cgstates->{$best->iq->project}->state->output_load->Rg_ws )
+            ,"color" => "blue"
+        ];
+} elseif ( isset( $cgstates->{$best->iq->project}->state->output_load->Rg ) ) {
     $rgdata->{ "Original model<br>Project " . $best->iq->project . "<br>SOMO computed" } =
         (object) [
             "Rg" => $cgstates->{$best->iq->project}->state->output_load->Rg
@@ -685,7 +693,7 @@ if ( isset( $cgstates->{$best->pr->project}->state->output_load->prplot ) ) {
         ];
 }
 
-joined_hist( $output, $iq_waxsis_nnlsresults, $iq_waxsis_nnlsresults_colors, $rgdata );
+joined_hist( $output, $iq_waxsis_nnlsresults, $iq_waxsis_nnlsresults_colors, $rgdata, $notes_rgs );
 
 $output->_textarea = '';
 

--- a/bin/joinresults.php
+++ b/bin/joinresults.php
@@ -665,13 +665,7 @@ $output->$pr_recon_id->layout->title->text =
 
 $rgdata = (object) [];
 
-if ( $use_solvated && isset( $cgstates->{$best->iq->project}->state->output_load->Rg_ws ) ) {
-    $rgdata->{ "Original model<br>Project " . $best->iq->project . "<br>WAXSiS (solv.)" } =
-        (object) [
-            "Rg" => floatval( $cgstates->{$best->iq->project}->state->output_load->Rg_ws )
-            ,"color" => "blue"
-        ];
-} elseif ( isset( $cgstates->{$best->iq->project}->state->output_load->Rg ) ) {
+if ( isset( $cgstates->{$best->iq->project}->state->output_load->Rg ) ) {
     $rgdata->{ "Original model<br>Project " . $best->iq->project . "<br>SOMO computed" } =
         (object) [
             "Rg" => $cgstates->{$best->iq->project}->state->output_load->Rg

--- a/bin/joinresults.php
+++ b/bin/joinresults.php
@@ -666,7 +666,7 @@ $output->$pr_recon_id->layout->title->text =
 $rgdata = (object) [];
 
 if ( isset( $cgstates->{$best->iq->project}->state->output_load->Rg ) ) {
-    $rgdata->{ "Original model<br>Project " . $best->iq->project . "<br>SOMO computed" } =
+    $rgdata->{ "Original model<br>Project " . $best->iq->project . "<br>SOMO (dry)" } =
         (object) [
             "Rg" => $cgstates->{$best->iq->project}->state->output_load->Rg
             ,"color" => "blue"

--- a/bin/plotlyhist.php
+++ b/bin/plotlyhist.php
@@ -3,7 +3,8 @@
 {};
 
 $plotly_hist_bin_count = 100;
-$show_dry_nnls_avg_marker = true; // set false to hide orange dry weighted-average marker when solvated Rg is used
+$show_dry_nnls_avg_marker = true;  // set false to hide orange dry weighted-average marker
+$use_solvated_bars        = false; // set true to use solvated Rg for bar positions and blue "Original model" marker
 
 function plotly_hist( $histname, $result, $stride = 0, $offset = 0, $adjacent = 0 ) {
     global $papercolors;
@@ -377,10 +378,11 @@ function final_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata, $adjac
             # need to sort nnlsresults
 
             $use_solvated = !empty( $notes_rgs ) && empty( array_diff_key( (array)$nnlsresults, $notes_rgs ) );
+            global $use_solvated_bars, $show_dry_nnls_avg_marker;
 
             $pos         = 0;
             $avgrg2      = 0;
-            $avgrg2_dry  = 0;
+            $avgrg2_solv = 0;
 
             foreach ( $nnlsresults as $k => $v ) {
                 $namev = explode( ' ', $k );
@@ -388,7 +390,7 @@ function final_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata, $adjac
                 $dry_rg = ( $model == "WAXSiS" || $model == 0 )
                     ? $cgstate->state->output_load->Rg
                     : $reshist->histplot->data[0]->y[ $model - 1 ];
-                $bar_rg = ( $use_solvated && isset( $notes_rgs[ $k ] ) ) ? $notes_rgs[ $k ]->rg : $dry_rg;
+                $bar_rg = ( $use_solvated && $use_solvated_bars && isset( $notes_rgs[ $k ] ) ) ? $notes_rgs[ $k ]->rg : $dry_rg;
 
                 $plot->data[2]->x[]             = floatval( sprintf( "%.1f", $bar_rg ) );
                 $plot->data[2]->y[]             = floatval( sprintf( "%.1f", 100 * $v ) );
@@ -400,12 +402,13 @@ function final_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata, $adjac
                     )
                     ? $nnlsresults_colors->$k
                     : "black";
-                $avgrg2     += $v * $bar_rg * $bar_rg;
-                $avgrg2_dry += $v * $dry_rg * $dry_rg;
+                $avgrg2 += $v * $dry_rg * $dry_rg;
+                if ( $use_solvated && isset( $notes_rgs[ $k ] ) ) {
+                    $avgrg2_solv += $v * $notes_rgs[ $k ]->rg * $notes_rgs[ $k ]->rg;
+                }
             }
 
-            $avgrg     = sqrt( $avgrg2 );
-            $avgrg_dry = sqrt( $avgrg2_dry );
+            $avgrg = sqrt( $avgrg2 );
 
             $plot->data[2]->width = ( max( $plot->data[0]->x ) - min( $plot->data[0]->x ) ) / (count( $plot->data[2]->x ) * 10 );
 
@@ -413,14 +416,11 @@ function final_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata, $adjac
                 $rgdata = (object)[];
             }
 
+            if ( $show_dry_nnls_avg_marker ) {
+                $rgdata->{ "Weighted avg. NNLS fit (dry)" }  = (object)[ "Rg" => $avgrg, "color" => "orange" ];
+            }
             if ( $use_solvated ) {
-                global $show_dry_nnls_avg_marker;
-                if ( $show_dry_nnls_avg_marker ) {
-                    $rgdata->{ "Weighted avg. NNLS fit (dry)" }  = (object)[ "Rg" => $avgrg_dry, "color" => "orange" ];
-                }
-                $rgdata->{ "Weighted avg. NNLS fit (solv.)" } = (object)[ "Rg" => $avgrg,     "color" => "green"  ];
-            } else {
-                $rgdata->{ "Weighted average of NNLS fit" }   = (object)[ "Rg" => $avgrg,     "color" => "green"  ];
+                $rgdata->{ "Weighted avg. NNLS fit (solv.)" } = (object)[ "Rg" => sqrt( $avgrg2_solv ), "color" => "green" ];
             }
             $rg_use_ordinate = [];
             
@@ -773,10 +773,11 @@ function joined_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata, $note
     $avgrg2 = 0;
 
     $use_solvated = !empty( $notes_rgs ) && empty( array_diff_key( (array)$nnlsresults, $notes_rgs ) );
+    global $use_solvated_bars, $show_dry_nnls_avg_marker;
 
     $pos         = 0;
     $avgrg2      = 0;
-    $avgrg2_dry  = 0;
+    $avgrg2_solv = 0;
 
     # file_put_contents( "/tmp/checkrg", "plotlyhist final func() running\n",  FILE_APPEND );
     foreach ( $nnlsresults as $k => $v ) {
@@ -791,7 +792,7 @@ function joined_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata, $note
         $dry_rg = ( $model == "WAXSiS" || $model == 0 )
             ? $cgstates->{$best->iq->project}->state->output_load->Rg
             : $reshists->$project->histplot->data[0]->y[ $model - 1 ];
-        $bar_rg = ( $use_solvated && isset( $notes_rgs[ $k ] ) ) ? $notes_rgs[ $k ]->rg : $dry_rg;
+        $bar_rg = ( $use_solvated && $use_solvated_bars && isset( $notes_rgs[ $k ] ) ) ? $notes_rgs[ $k ]->rg : $dry_rg;
 
         $plot->data[2]->x[]             = floatval( sprintf( "%.1f", $bar_rg ) );
         $plot->data[2]->y[]             = floatval( sprintf( "%.1f", 100 * $v ) );
@@ -803,12 +804,13 @@ function joined_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata, $note
             )
             ? $nnlsresults_colors->$k
             : "black";
-        $avgrg2     += $v * $bar_rg * $bar_rg;
-        $avgrg2_dry += $v * $dry_rg * $dry_rg;
+        $avgrg2 += $v * $dry_rg * $dry_rg;
+        if ( $use_solvated && isset( $notes_rgs[ $k ] ) ) {
+            $avgrg2_solv += $v * $notes_rgs[ $k ]->rg * $notes_rgs[ $k ]->rg;
+        }
     }
 
-    $avgrg     = sqrt( $avgrg2 );
-    $avgrg_dry = sqrt( $avgrg2_dry );
+    $avgrg = sqrt( $avgrg2 );
 
     $plot->data[2]->width = ( max( $plot->data[0]->x ) - min( $plot->data[0]->x ) ) / (count( $plot->data[2]->x ) * 10 );
 
@@ -816,14 +818,11 @@ function joined_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata, $note
         $rgdata = (object)[];
     }
 
+    if ( $show_dry_nnls_avg_marker ) {
+        $rgdata->{ "Weighted avg. NNLS fit (dry)" }  = (object)[ "Rg" => $avgrg, "color" => "orange" ];
+    }
     if ( $use_solvated ) {
-        global $show_dry_nnls_avg_marker;
-        if ( $show_dry_nnls_avg_marker ) {
-            $rgdata->{ "Weighted avg. NNLS fit (dry)" }  = (object)[ "Rg" => $avgrg_dry, "color" => "orange" ];
-        }
-        $rgdata->{ "Weighted avg. NNLS fit (solv.)" } = (object)[ "Rg" => $avgrg,     "color" => "green"  ];
-    } else {
-        $rgdata->{ "Weighted average of NNLS fit" }   = (object)[ "Rg" => $avgrg,     "color" => "green"  ];
+        $rgdata->{ "Weighted avg. NNLS fit (solv.)" } = (object)[ "Rg" => sqrt( $avgrg2_solv ), "color" => "green" ];
     }
     $rg_use_ordinate = [];
     

--- a/bin/plotlyhist.php
+++ b/bin/plotlyhist.php
@@ -394,7 +394,7 @@ function final_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata, $adjac
 
                 $plot->data[2]->x[]             = floatval( sprintf( "%.1f", $bar_rg ) );
                 $plot->data[2]->y[]             = floatval( sprintf( "%.1f", 100 * $v ) );
-                $plot->data[2]->customdata[]    = "Model $model";
+                $plot->data[2]->customdata[]    = "Model $model (dry)";
                 $plot->data[2]->marker->color[] =
                     (
                      isset( $nnlsresults_colors )
@@ -796,7 +796,7 @@ function joined_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata, $note
 
         $plot->data[2]->x[]             = floatval( sprintf( "%.1f", $bar_rg ) );
         $plot->data[2]->y[]             = floatval( sprintf( "%.1f", 100 * $v ) );
-        $plot->data[2]->customdata[]    = "$project Model $model";
+        $plot->data[2]->customdata[]    = "$project Model $model (dry)";
         $plot->data[2]->marker->color[] =
             (
              isset( $nnlsresults_colors )
@@ -866,7 +866,7 @@ $sas->compute_rg_from_pr( "Exp. P(r)", $prrg );
 echo "rg is $prrg\n";
 
 $rgdata = (object) [
-    "Original model<br>SOMO computed" => (object) [
+    "Original model<br>SOMO (dry)" => (object) [
         "Rg" => $cgstate->state->output_load->Rg
         ,"color" => "blue"
     ]

--- a/bin/plotlyhist.php
+++ b/bin/plotlyhist.php
@@ -3,6 +3,7 @@
 {};
 
 $plotly_hist_bin_count = 100;
+$show_dry_nnls_avg_marker = true; // set false to hide orange dry weighted-average marker when solvated Rg is used
 
 function plotly_hist( $histname, $result, $stride = 0, $offset = 0, $adjacent = 0 ) {
     global $papercolors;
@@ -235,7 +236,7 @@ function plotly_hist( $histname, $result, $stride = 0, $offset = 0, $adjacent = 
     return "";
 }
 
-function final_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata, $adjacent = 0 ) {
+function final_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata, $adjacent = 0, $notes_rgs = null ) {
     global $cgstate;
 
     if ( isset( $cgstate->state->mmcdownloaded ) ) {
@@ -375,54 +376,52 @@ function final_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata, $adjac
             
             # need to sort nnlsresults
 
-            $pos    = 0;
-            $avgrg2 = 0;
+            $use_solvated = !empty( $notes_rgs ) && empty( array_diff_key( (array)$nnlsresults, $notes_rgs ) );
+
+            $pos         = 0;
+            $avgrg2      = 0;
+            $avgrg2_dry  = 0;
 
             foreach ( $nnlsresults as $k => $v ) {
                 $namev = explode( ' ', $k );
                 $model = end( $namev );
-                if ( $model == "WAXSiS" || $model == 0 ) {
-                    $plot->data[2]->x[]             = floatval( sprintf( "%.1f", $cgstate->state->output_load->Rg ) );
-                    $plot->data[2]->y[]             = floatval( sprintf( "%.1f", 100 * $v ) );
-                    $plot->data[2]->customdata[]    = "Model $model";
-                    $plot->data[2]->marker->color[] =
-                        (
-                         isset( $nnlsresults_colors )
-                         && isset( $nnlsresults_colors->$k )
-                        )
-                        ? $nnlsresults_colors->$k
-                        : "black";
-                    $avgrg2 += $v * $cgstate->state->output_load->Rg * $cgstate->state->output_load->Rg;
-                } else {
-                    $plot->data[2]->x[]             = floatval( sprintf( "%.1f", $reshist->histplot->data[0]->y[ $model - 1 ] ) );
-                    $plot->data[2]->y[]             = floatval( sprintf( "%.1f", 100 * $v ) );
-                    $plot->data[2]->customdata[]    = "Model $model";
-                    $plot->data[2]->marker->color[] =
-                        (
-                         isset( $nnlsresults_colors )
-                         && isset( $nnlsresults_colors->$k )
-                        )
-                        ? $nnlsresults_colors->$k
-                        : "black";
-                    $avgrg2 += $v * $reshist->histplot->data[0]->y[ $model - 1 ] * $reshist->histplot->data[0]->y[ $model - 1 ];
-                }
+                $dry_rg = ( $model == "WAXSiS" || $model == 0 )
+                    ? $cgstate->state->output_load->Rg
+                    : $reshist->histplot->data[0]->y[ $model - 1 ];
+                $bar_rg = ( $use_solvated && isset( $notes_rgs[ $k ] ) ) ? $notes_rgs[ $k ]->rg : $dry_rg;
+
+                $plot->data[2]->x[]             = floatval( sprintf( "%.1f", $bar_rg ) );
+                $plot->data[2]->y[]             = floatval( sprintf( "%.1f", 100 * $v ) );
+                $plot->data[2]->customdata[]    = "Model $model";
+                $plot->data[2]->marker->color[] =
+                    (
+                     isset( $nnlsresults_colors )
+                     && isset( $nnlsresults_colors->$k )
+                    )
+                    ? $nnlsresults_colors->$k
+                    : "black";
+                $avgrg2     += $v * $bar_rg * $bar_rg;
+                $avgrg2_dry += $v * $dry_rg * $dry_rg;
             }
 
-            $avgrg = sqrt( $avgrg2 );
+            $avgrg     = sqrt( $avgrg2 );
+            $avgrg_dry = sqrt( $avgrg2_dry );
 
             $plot->data[2]->width = ( max( $plot->data[0]->x ) - min( $plot->data[0]->x ) ) / (count( $plot->data[2]->x ) * 10 );
-
-            $avgrg_key  = "Weighted average of NNLS fit";
-            $avgrg_value = (object) [
-                "Rg" => $avgrg
-                ,"color" => "green"
-                ];
 
             if ( !isset( $rgdata ) || !is_object( $rgdata ) ) {
                 $rgdata = (object)[];
             }
 
-            $rgdata->{$avgrg_key} = $avgrg_value;
+            if ( $use_solvated ) {
+                global $show_dry_nnls_avg_marker;
+                if ( $show_dry_nnls_avg_marker ) {
+                    $rgdata->{ "Weighted avg. NNLS fit (dry)" }  = (object)[ "Rg" => $avgrg_dry, "color" => "orange" ];
+                }
+                $rgdata->{ "Weighted avg. NNLS fit (solv.)" } = (object)[ "Rg" => $avgrg,     "color" => "green"  ];
+            } else {
+                $rgdata->{ "Weighted average of NNLS fit" }   = (object)[ "Rg" => $avgrg,     "color" => "green"  ];
+            }
             $rg_use_ordinate = [];
             
             foreach ( $rgdata as $k => $v ) {
@@ -492,7 +491,7 @@ function merge_histograms( $x1, $y1, $x2, $y2, $n_bins ) {
     return [ $bins, $counts ];
 }
 
-function joined_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata ) {
+function joined_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata, $notes_rgs = null ) {
     global $cgstates;
     global $best;
     global $plotly_hist_bin_count;
@@ -773,58 +772,59 @@ function joined_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata ) {
     $pos    = 0;
     $avgrg2 = 0;
 
+    $use_solvated = !empty( $notes_rgs ) && empty( array_diff_key( (array)$nnlsresults, $notes_rgs ) );
+
+    $pos         = 0;
+    $avgrg2      = 0;
+    $avgrg2_dry  = 0;
+
     # file_put_contents( "/tmp/checkrg", "plotlyhist final func() running\n",  FILE_APPEND );
     foreach ( $nnlsresults as $k => $v ) {
         if ( !preg_match( '/^([^:]*):/', $k, $matches ) ) {
             return "Error: Could not determine project name from '$name'";
         }
         $project = $matches[1];
-        
+
         $namev = explode( ' ', $k );
         $model = end( $namev );
 
-        if ( $model == "WAXSiS" || $model == 0 ) {
-            $plot->data[2]->x[]             = floatval( sprintf( "%.1f", $cgstates->{$best->iq->project}->state->output_load->Rg ) );
-            $plot->data[2]->y[]             = floatval( sprintf( "%.1f", 100 * $v ) );
-            $plot->data[2]->customdata[]    = "$project Model $model";
-            $plot->data[2]->marker->color[] =
-                (
-                 isset( $nnlsresults_colors )
-                 && isset( $nnlsresults_colors->$k )
-                )
-                ? $nnlsresults_colors->$k
-                : "black";
-            $avgrg2 += $v * $cgstates->{$best->iq->project}->state->output_load->Rg * $cgstates->{$best->iq->project}->state->output_load->Rg;
-        } else {
-            $plot->data[2]->x[]             = floatval( sprintf( "%.1f", $reshists->$project->histplot->data[0]->y[ $model - 1 ] ) );
-            $plot->data[2]->y[]             = floatval( sprintf( "%.1f", 100 * $v ) );
-            $plot->data[2]->customdata[]    = "$project Model $model";
-            $plot->data[2]->marker->color[] =
-                (
-                 isset( $nnlsresults_colors )
-                 && isset( $nnlsresults_colors->$k )
-                )
-                ? $nnlsresults_colors->$k
-                : "black";
-            $avgrg2 += $v * $reshists->$project->histplot->data[0]->y[ $model - 1 ] * $reshists->$project->histplot->data[0]->y[ $model - 1 ];
-        }
+        $dry_rg = ( $model == "WAXSiS" || $model == 0 )
+            ? $cgstates->{$best->iq->project}->state->output_load->Rg
+            : $reshists->$project->histplot->data[0]->y[ $model - 1 ];
+        $bar_rg = ( $use_solvated && isset( $notes_rgs[ $k ] ) ) ? $notes_rgs[ $k ]->rg : $dry_rg;
+
+        $plot->data[2]->x[]             = floatval( sprintf( "%.1f", $bar_rg ) );
+        $plot->data[2]->y[]             = floatval( sprintf( "%.1f", 100 * $v ) );
+        $plot->data[2]->customdata[]    = "$project Model $model";
+        $plot->data[2]->marker->color[] =
+            (
+             isset( $nnlsresults_colors )
+             && isset( $nnlsresults_colors->$k )
+            )
+            ? $nnlsresults_colors->$k
+            : "black";
+        $avgrg2     += $v * $bar_rg * $bar_rg;
+        $avgrg2_dry += $v * $dry_rg * $dry_rg;
     }
 
-    $avgrg = sqrt( $avgrg2 );
+    $avgrg     = sqrt( $avgrg2 );
+    $avgrg_dry = sqrt( $avgrg2_dry );
 
     $plot->data[2]->width = ( max( $plot->data[0]->x ) - min( $plot->data[0]->x ) ) / (count( $plot->data[2]->x ) * 10 );
-
-    $avgrg_key  = "Weighted average of NNLS fit";
-    $avgrg_value = (object) [
-        "Rg" => $avgrg
-        ,"color" => "green"
-        ];
 
     if ( !isset( $rgdata ) || !is_object( $rgdata ) ) {
         $rgdata = (object)[];
     }
 
-    $rgdata->{$avgrg_key} = $avgrg_value;
+    if ( $use_solvated ) {
+        global $show_dry_nnls_avg_marker;
+        if ( $show_dry_nnls_avg_marker ) {
+            $rgdata->{ "Weighted avg. NNLS fit (dry)" }  = (object)[ "Rg" => $avgrg_dry, "color" => "orange" ];
+        }
+        $rgdata->{ "Weighted avg. NNLS fit (solv.)" } = (object)[ "Rg" => $avgrg,     "color" => "green"  ];
+    } else {
+        $rgdata->{ "Weighted average of NNLS fit" }   = (object)[ "Rg" => $avgrg,     "color" => "green"  ];
+    }
     $rg_use_ordinate = [];
     
     foreach ( $rgdata as $k => $v ) {

--- a/bin/waxsis.php
+++ b/bin/waxsis.php
@@ -148,6 +148,21 @@ function run_waxsis( $pdb, $config, $cb_on_write, $exit_waxsis_error = true ) {
     return true;
 }
 
+function waxsis_rg_from_notes( $notes_file ) {
+    if ( !file_exists( $notes_file ) ) {
+        error_exit( "WAXSiS notes file '$notes_file' does not exist" );
+    }
+    $content = file_get_contents( $notes_file );
+    if ( !preg_match( '/Rg \[A\]\s*=\s*([\d.]+)/', $content, $m ) ) {
+        error_exit( "Could not parse Rg from WAXSiS notes file '$notes_file'" );
+    }
+    $rg = floatval( $m[1] );
+    if ( !preg_match( '/Rg\(solute\) \[A\]\s*=\s*([\d.]+)/', $content, $m ) ) {
+        error_exit( "Could not parse Rg(solute) from WAXSiS notes file '$notes_file'" );
+    }
+    return (object)[ 'rg' => $rg, 'rg_solute' => floatval( $m[1] ) ];
+}
+
 ## testing
 
 # waxis_load_data( "waxsis/fittedCalcInterpolated_waxsis.fit", $waxsis_fitted_data );


### PR DESCRIPTION
When WAXSiS notes files exist for all NNLS-selected models:
- Bar chart (NNLS fitting models Rg) uses solvated Rg as x-position
- "Original model" blue marker switches to WAXSiS solvated Rg (Rg_ws)
- Weighted average marker splits: orange (dry, toggled by \$show_dry_nnls_avg_marker flag) and green (solvated) Falls back silently to existing dry/MMC behavior when notes unavailable.