### PR TITLE
Replace deprecated Chart Studio link with local chart editor

### DIFF
--- a/bin/plotlyhist.php
+++ b/bin/plotlyhist.php
@@ -76,6 +76,15 @@ function plotly_hist( $histname, $result, $stride = 0, $offset = 0, $adjacent = 
                            ,"showline"       : true
                         }
                      }
+                     ,"config" : {
+                        "showLink"         : false
+                        ,"responsive"      : true
+                        ,"genapp_chart_editor" : {
+                            "enabled" : true
+                            ,"url"    : "_cedit/_chart_edit.html"
+                            ,"target" : "_blank"
+                        }
+                     }
                 }'
                 );
 
@@ -132,6 +141,15 @@ function plotly_hist( $histname, $result, $stride = 0, $offset = 0, $adjacent = 
                             }
                          }
                            ,"showline"       : true
+                        }
+                     }
+                     ,"config" : {
+                        "showLink"         : false
+                        ,"responsive"      : true
+                        ,"genapp_chart_editor" : {
+                            "enabled" : true
+                            ,"url"    : "_cedit/_chart_edit.html"
+                            ,"target" : "_blank"
                         }
                      }
                 }'

--- a/bin/plotlyhist.php
+++ b/bin/plotlyhist.php
@@ -309,7 +309,7 @@ function final_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata, $adjac
             $plot = (object) array_merge( (array) $plot,
                                           [
                                            "config" => [
-                                           "showLink"         => true
+                                           "showLink"         => false
                                            ,"responsive"      => true
                                            ,"genapp_chart_editor" => [
                                                "enabled" => true
@@ -703,7 +703,7 @@ function joined_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata, $note
     $plot = (object) array_merge( (array) $plot,
                                   [
                                    "config" => [
-                                           "showLink"         => true
+                                           "showLink"         => false
                                            ,"responsive"      => true
                                            ,"genapp_chart_editor" => [
                                                "enabled" => true

--- a/bin/plotlyhist.php
+++ b/bin/plotlyhist.php
@@ -310,10 +310,12 @@ function final_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata, $adjac
                                           [
                                            "config" => [
                                            "showLink"         => true
-                                           ,"plotlyServerURL" => "https://cloud.plotly.com"
-                                           ,"showSendToCloud" => true
                                            ,"responsive"      => true
-                                           ,"linkText"        => "Edit chart"
+                                           ,"genapp_chart_editor" => [
+                                               "enabled" => true
+                                               ,"url"    => "_cedit/_chart_edit.html"
+                                               ,"target" => "_blank"
+                                           ]
                                            ]
                                           ] );
                                            
@@ -702,10 +704,12 @@ function joined_hist( $result, $nnlsresults, $nnlsresults_colors, $rgdata, $note
                                   [
                                    "config" => [
                                            "showLink"         => true
-                                           ,"plotlyServerURL" => "https://cloud.plotly.com"
-                                           ,"showSendToCloud" => true
                                            ,"responsive"      => true
-                                           ,"linkText"        => "Edit chart"
+                                           ,"genapp_chart_editor" => [
+                                               "enabled" => true
+                                               ,"url"    => "_cedit/_chart_edit.html"
+                                               ,"target" => "_blank"
+                                           ]
                                    ]
                                   ] );
 

--- a/bin/sas.php
+++ b/bin/sas.php
@@ -140,10 +140,12 @@ class SAS {
                  }
                  ,"config" : {
                     "showLink"         : true
-                    ,"plotlyServerURL" : "https://cloud.plotly.com"
-                    ,"showSendToCloud" : true
                     ,"responsive"      : true
-                    ,"linkText"        : "Edit chart"
+                    ,"genapp_chart_editor" : {
+                        "enabled" : true
+                        ,"url"    : "_cedit/_chart_edit.html"
+                        ,"target" : "_blank"
+                    }
                  }
             }'
         )
@@ -229,10 +231,12 @@ class SAS {
                  }
                  ,"config" : {
                     "showLink"         : true
-                    ,"plotlyServerURL" : "https://cloud.plotly.com"
-                    ,"showSendToCloud" : true
                     ,"responsive"      : true
-                    ,"linkText"        : "Edit chart"
+                    ,"genapp_chart_editor" : {
+                        "enabled" : true
+                        ,"url"    : "_cedit/_chart_edit.html"
+                        ,"target" : "_blank"
+                    }
                  }
             }'
         )
@@ -1015,6 +1019,7 @@ class SAS {
 
                 case "showeditchart" :
                     $this->plots->$name->config->showLink = $v;
+                    $this->plots->$name->config->genapp_chart_editor->enabled = $v;
                     break;
 
                 case "yaxistitle" :

--- a/bin/sas.php
+++ b/bin/sas.php
@@ -139,7 +139,7 @@ class SAS {
                    ]
                  }
                  ,"config" : {
-                    "showLink"         : true
+                    "showLink"         : false
                     ,"responsive"      : true
                     ,"genapp_chart_editor" : {
                         "enabled" : true
@@ -230,7 +230,7 @@ class SAS {
                    ]
                  }
                  ,"config" : {
-                    "showLink"         : true
+                    "showLink"         : false
                     ,"responsive"      : true
                     ,"genapp_chart_editor" : {
                         "enabled" : true
@@ -1018,7 +1018,6 @@ class SAS {
                     break;
 
                 case "showeditchart" :
-                    $this->plots->$name->config->showLink = $v;
                     $this->plots->$name->config->genapp_chart_editor->enabled = $v;
                     break;
 


### PR DESCRIPTION
## Summary
- Drops dead plotlyServerURL/showSendToCloud/linkText config (cloud.plotly.com Chart Studio is gone) from all 4 plot config blocks.
- Adds opt-in genapp_chart_editor config (enabled: true, url: _cedit/_chart_edit.html, target: _blank), which makes genapp data.js add an Edit in Chart Editor modebar button opening the local react-chart-editor.
- showeditchart field now also toggles genapp_chart_editor.enabled (so plots that hide the old edit-chart link also hide the new editor button).

## Test plan
- [ ] Run a project through computeiqpr and confirm the new pencil Edit in Chart Editor modebar icon appears on I(q)/P(r) plots and opens the local chart editor with correct data.
- [ ] Confirm plots created with showeditchart => false (computeiqpr_funcs.php) show neither the old edit link nor the new editor button.
- [ ] Confirm finalmodel/joinresults histogram plots (plotlyhist.php) show the new editor button.

Generated with Claude Code