### PR TITLE
Add linewidth cycle modeBar button to all IQ/PR plots

### DIFF
--- a/bin/common.php
+++ b/bin/common.php
@@ -333,6 +333,12 @@ function upgrade_plot_config( $config ) {
         ,"target" => "_blank"
     ];
 
+    // temporary until upgrade_plot_config is deprecated
+    $arr['genapp_plotly'] = (object) [
+        "linewidth"  => (object) [ "values" => [1, 2, 3] ]
+        ,"errorbars" => (object) []
+    ];
+
     return (object) $arr;
 }
 

--- a/bin/common.php
+++ b/bin/common.php
@@ -335,7 +335,7 @@ function upgrade_plot_config( $config ) {
 
     // temporary until upgrade_plot_config is deprecated
     $arr['genapp_plotly'] = (object) [
-        "linewidth"  => (object) [ "values" => [1, 2, 3] ]
+        "linewidth"  => (object) [ "values" => [1, 2, 3, 4] ]
         ,"errorbars" => (object) []
     ];
 

--- a/bin/plotlyhist.php
+++ b/bin/plotlyhist.php
@@ -85,7 +85,7 @@ function plotly_hist( $histname, $result, $stride = 0, $offset = 0, $adjacent = 
                             ,"target" : "_blank"
                         }
                         ,"genapp_plotly" : {
-                            "linewidth"  : { "values" : [1, 2, 3] }
+                            "linewidth"  : { "values" : [1, 2, 3, 4] }
                             ,"errorbars" : {}
                         }
                      }
@@ -156,7 +156,7 @@ function plotly_hist( $histname, $result, $stride = 0, $offset = 0, $adjacent = 
                             ,"target" : "_blank"
                         }
                         ,"genapp_plotly" : {
-                            "linewidth"  : { "values" : [1, 2, 3] }
+                            "linewidth"  : { "values" : [1, 2, 3, 4] }
                             ,"errorbars" : {}
                         }
                      }

--- a/bin/plotlyhist.php
+++ b/bin/plotlyhist.php
@@ -84,6 +84,10 @@ function plotly_hist( $histname, $result, $stride = 0, $offset = 0, $adjacent = 
                             ,"url"    : "_cedit/_chart_edit.html"
                             ,"target" : "_blank"
                         }
+                        ,"genapp_plotly" : {
+                            "linewidth"  : { "values" : [1, 2, 3] }
+                            ,"errorbars" : {}
+                        }
                      }
                 }'
                 );
@@ -150,6 +154,10 @@ function plotly_hist( $histname, $result, $stride = 0, $offset = 0, $adjacent = 
                             "enabled" : true
                             ,"url"    : "_cedit/_chart_edit.html"
                             ,"target" : "_blank"
+                        }
+                        ,"genapp_plotly" : {
+                            "linewidth"  : { "values" : [1, 2, 3] }
+                            ,"errorbars" : {}
                         }
                      }
                 }'

--- a/bin/sas.php
+++ b/bin/sas.php
@@ -147,7 +147,8 @@ class SAS {
                         ,"target" : "_blank"
                     }
                     ,"genapp_plotly" : {
-                        "linewidth" : { "values" : [1, 2, 3] }
+                        "linewidth"  : { "values" : [1, 2, 3] }
+                        ,"errorbars" : {}
                     }
                  }
             }'
@@ -241,7 +242,8 @@ class SAS {
                         ,"target" : "_blank"
                     }
                     ,"genapp_plotly" : {
-                        "linewidth" : { "values" : [1, 2, 3] }
+                        "linewidth"  : { "values" : [1, 2, 3] }
+                        ,"errorbars" : {}
                     }
                  }
             }'

--- a/bin/sas.php
+++ b/bin/sas.php
@@ -146,6 +146,9 @@ class SAS {
                         ,"url"    : "_cedit/_chart_edit.html"
                         ,"target" : "_blank"
                     }
+                    ,"genapp_plotly" : {
+                        "linewidth" : { "values" : [1, 2, 3] }
+                    }
                  }
             }'
         )
@@ -236,6 +239,9 @@ class SAS {
                         "enabled" : true
                         ,"url"    : "_cedit/_chart_edit.html"
                         ,"target" : "_blank"
+                    }
+                    ,"genapp_plotly" : {
+                        "linewidth" : { "values" : [1, 2, 3] }
                     }
                  }
             }'

--- a/bin/sas.php
+++ b/bin/sas.php
@@ -147,7 +147,7 @@ class SAS {
                         ,"target" : "_blank"
                     }
                     ,"genapp_plotly" : {
-                        "linewidth"  : { "values" : [1, 2, 3] }
+                        "linewidth"  : { "values" : [1, 2, 3, 4] }
                         ,"errorbars" : {}
                     }
                  }
@@ -242,7 +242,7 @@ class SAS {
                         ,"target" : "_blank"
                     }
                     ,"genapp_plotly" : {
-                        "linewidth"  : { "values" : [1, 2, 3] }
+                        "linewidth"  : { "values" : [1, 2, 3, 4] }
                         ,"errorbars" : {}
                     }
                  }


### PR DESCRIPTION
## Summary

- Adds genapp_plotly.linewidth and errorbars config to PLOT_IQ and PLOT_PR templates in SAS class
- Adds same to MMC Rg and MMC Rg Histogram plots in plotlyhist.php
- Adds same to upgrade_plot_config in common.php (temporary, covers cached state; to be removed when upgrade_plot_config is deprecated)
- All affected plots get a modeBar button to cycle line width through [1, 2, 3, 4] and a toggle button for error bars
- Histogram and other non-IQ/PR plot types are unaffected
- Depends on genapp PR ehb54/genapp#29 (ga.data.plotly namespace + modeBar button support)

## Test plan

- [ ] IQ plots show linewidth cycle and errorbars toggle buttons in modeBar
- [ ] P(r) plots show linewidth cycle and errorbars toggle buttons in modeBar
- [ ] MMC Rg and MMC Rg Histogram plots show both buttons
- [ ] Clicking linewidth cycles: 1 -> 2 -> 3 -> 4 -> 1
- [ ] Clicking errorbars toggles visibility
- [ ] Histogram and other plots are unaffected

Generated with Claude Code