### PR TITLE
Fix runs-test p-value collapsing to 0 for grids over ~1024 points

### DIFF
--- a/bin/sas.php
+++ b/bin/sas.php
@@ -2753,7 +2753,8 @@ class SAS {
     # Uses the exact probability that a longest run of length >= longest_run occurs by chance
     # in n Bernoulli trials (p=0.5), via the recurrence:
     #   P(longest run >= k | n) = 1 - P(longest run < k | n)
-    # where P(longest run < k | n) is computed with the standard recurrence on exact counts.
+    # where P(longest run < k | n) is computed with the standard recurrence, carried in
+    # probabilities so it stays bounded for large n.
     # $results is populated with: p_value, longest_run, total_length, run_direction
     function compute_p_value( $name1, $name2, &$results ) {
         $this->debug_msg( "SAS::compute_p_value( '$name1', '$name2' )" );
@@ -2833,14 +2834,17 @@ class SAS {
         ## outcomes is at least k under a fair coin (p=0.5) null model, where each point
         ## is independently either y1>y2 or y1<y2 with equal probability.
         ##
-        ## State-based recurrence: g[j] = count of binary strings of current length
-        ## whose longest ending run has exactly j equal symbols (j = 1..k-1):
-        ##   g(1)[1] = 2
-        ##   g(i)[j] = g(i-1)[j-1]                for j = 2..k-1  (extend run by same symbol)
-        ##   g(i)[1] = sum_{j=1}^{k-1} g(i-1)[j]  (break any run, start with other symbol)
-        ## f(n, k) = sum_{j=1}^{k-1} g(n)[j]      (strings of length n with no run >= k)
-        ## P(L < k | n) = f(n, k) / 2^n
+        ## State-based recurrence: g[j] = probability that a random string of the current
+        ## length has no run >= k and ends in a run of exactly j equal symbols (j = 1..k-1):
+        ##   g(1)[1] = 1
+        ##   g(i)[j] = g(i-1)[j-1] / 2                for j = 2..k-1  (extend run by same symbol)
+        ##   g(i)[1] = sum_{j=1}^{k-1} g(i-1)[j] / 2  (break any run, start with other symbol)
+        ## P(L < k | n) = sum_{j=1}^{k-1} g(n)[j]
         ## p_value = 1 - P(L < k | n)
+        ##
+        ## Carried as probabilities rather than as string counts: the count form of this
+        ## recurrence grows like 2^n and overflows a double past n ~ 1024, which drove
+        ## p_value to exactly 0 for any grid larger than that. Every value here stays in [0,1].
 
         $k = $longest_run;
 
@@ -2848,14 +2852,14 @@ class SAS {
             $p_value = 1.0;
         } else {
             $g    = array_fill( 1, $k - 1, 0.0 );
-            $g[1] = 2.0;
+            $g[1] = 1.0;
 
             for ( $i = 2; $i <= $n; ++$i ) {
                 $new_g = array_fill( 1, $k - 1, 0.0 );
 
                 ## extend ending runs of length j-1 to j (append same symbol)
                 for ( $j = 2; $j <= $k - 1; ++$j ) {
-                    $new_g[$j] = $g[$j - 1];
+                    $new_g[$j] = 0.5 * $g[$j - 1];
                 }
 
                 ## break any ending run: append the other symbol, starting a run of 1
@@ -2863,20 +2867,17 @@ class SAS {
                 for ( $j = 1; $j <= $k - 1; ++$j ) {
                     $total += $g[$j];
                 }
-                $new_g[1] = $total;
+                $new_g[1] = 0.5 * $total;
 
                 $g = $new_g;
             }
 
-            $f = 0.0;
+            $prob_less = 0.0;
             for ( $j = 1; $j <= $k - 1; ++$j ) {
-                $f += $g[$j];
+                $prob_less += $g[$j];
             }
 
-            ## log-space to avoid overflow for large n
-            $log_prob_less = log( max( $f, 1e-300 ) ) - $n * log( 2.0 );
-            $prob_less     = exp( $log_prob_less );
-            $p_value       = max( 0.0, 1.0 - $prob_less );
+            $p_value = min( 1.0, max( 0.0, 1.0 - $prob_less ) );
         }
 
         ## --- populate result object ---


### PR DESCRIPTION
## Problem

`SAS::compute_p_value()` reported **P = 0 for any dataset with more than ~1024 points**, regardless of how good the fit actually was. Reported by Mattia on a 1045-point WAXSiS NNLS fit: SAF said P=0, US-SOMO said 0.031 on the same data.

This is a numeric overflow, not a statistics error. The longest-run recurrence was carried as raw **counts of binary strings**, which grow like 2^n. Past n ≈ 1024 those counts overflow a double to `INF`, so `max(0.0, 1.0 - INF)` collapsed to exactly 0:

| n | p (k=15) |
|---|---|
| 1023 | 0.0303657 |
| 1024 | 0.0303953 |
| 1030 | **0.0000000** |
| 1045 | **0.0000000** |

The existing `log()`-based step could not help — the log was taken *after* the sum had already overflowed.

## Fix

Carry the same recurrence in **probabilities** instead of counts (init `1.0`, halve on both transitions) so every value stays in `[0,1]`. The recurrence itself was already correct and is unchanged; only its scaling differs. No API or output-shape change.

## Verification

- Matches **exact rational arithmetic** to 7 significant digits for n up to 20000.
- Recurrence independently validated against **brute-force enumeration** of all binary strings for n = 2..14 over every k.
- End-to-end through the real `SAS` class on the reported 1045-point CSV: p-value goes **0.0000000 → 0.0611514**, with `longest_run` (14) and `total_length` (1045) unchanged, confirming run detection was never at fault.
- `php -l` clean under PHP 7.4.3 (the production version).

## Note on the SOMO comparison

This does **not** make SAF match US-SOMO's 0.0310463, and that is expected. SOMO's `US_Saxs_Util::cormap()` calls `prob_of_streak_f( N, C )` with N = number of points and C = run length, but that formula expects *adjacent-comparison* counts; the correct call would be `prob_of_streak( N-1, C-1 )`. Brute force confirms SAF's post-fix value is the statistically correct one:

| n points, run k | truth (brute force) | SOMO `prob_of_streak(n,k)` | `prob_of_streak(n-1,k-1)` |
|---|---|---|---|
| 12, 4 | 0.5473633 | 0.2988281 | 0.5473633 |
| 15, 5 | 0.3486938 | 0.1826172 | 0.3486938 |
| 20, 4 | 0.7684193 | 0.4780188 | 0.7684193 |

Per maintainer decision, SAF keeps the correct ("truth") values for now; reconciling with SOMO/ATSAS CorMap convention is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
